### PR TITLE
Revert back to a design where assignments are grouped by the invitation that they belong to.

### DIFF
--- a/www/templates/default/UNL/VisitorChat/Invitation/RecordList.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Invitation/RecordList.tpl.php
@@ -14,13 +14,18 @@ foreach ($context as $invitation) {
         $name = $account->name;
     }
     
-    echo "<li><ul class='$class'>";
+    echo "<li class='$class'>
+              <span>Invitation to: $name</span>
+              <span class='timestamp'>" . date("g:i:s A", strtotime($invitation->date_created)) . "</span>
+              <ul>";
     foreach ($invitation->getAssignments() as $assignment) {
-        //$class = strtolower($assignment->status);
-        echo "<li>" . $assignment->getUser()->name . "<span class='userAddress'>" . $name
-        . "<span class='timestamp'>" . date("g:i:s A", strtotime($invitation->date_created)) . "</span></li></span>";
+        $class = strtolower($assignment->status);
+        echo "<li class='$class'>
+                  " . $assignment->getUser()->name . "
+                  <span class='timestamp'>" . date("g:i:s A", strtotime($assignment->date_created)) . "</span>
+              </li>";
     }
-    echo "</li></ul>";
+    echo "</ul></li>";
 }
 ?>
 </ul>


### PR DESCRIPTION
This way an operator can easily see the status of their invitation and past invitations.
