### PR TITLE
update a test to reflect recent changes:

### DIFF
--- a/tests/Application/UNL/VisitorChat/User/ClientLogin_nooperators.phpt
+++ b/tests/Application/UNL/VisitorChat/User/ClientLogin_nooperators.phpt
@@ -24,8 +24,6 @@ $result = $app->render();
 
 $result = json_decode($result, true);
 
-echo "latest_message_id: " . $result['latest_message_id'] . PHP_EOL;
-
 echo "status: " . $result['status'] . PHP_EOL;
 
 echo "conversation_id: " . $result['conversation_id'] . PHP_EOL;
@@ -37,7 +35,6 @@ if (isset($result['phpssid'])) {
 ?>
 ===DONE===
 --EXPECT--
-latest_message_id: 0
 status: EMAILED
 conversation_id: 1
 phpssid: 1


### PR DESCRIPTION
The latest_message_id conversation variable is no longer needed.
