### PR TITLE
dispaly the chat log after the conversation has ended.

### DIFF
--- a/src/UNL/VisitorChat/Conversation/View.php
+++ b/src/UNL/VisitorChat/Conversation/View.php
@@ -56,14 +56,14 @@ class View
                 $this->operators[] = $operator->name;
             }
         }
-        
-        //The rest of the logic only applies if we are currently chatting.
-        if ($this->conversation->status !== 'CHATTING') {
-            return;
-        }
-        
+
         if (isset($options['last'])) {
             $this->request_id = $options['last'];
+        }
+
+        //The rest of the logic only applies if we are currently chatting.
+        if ($this->conversation->status !== 'CHATTING' && !($this->conversation->status == 'CLOSED' && $this->request_id == 0)) {
+            return;
         }
         
         $this->messages = \UNL\VisitorChat\Message\RecordList::getMessagesAfterIDForConversation($this->conversation_id, $this->request_id);

--- a/www/js/VisitorChat/ChatBase.js
+++ b/www/js/VisitorChat/ChatBase.js
@@ -383,9 +383,21 @@ var VisitorChat_ChatBase = Class.extend({
      * from their end or the current operator logs out.
      */
     onConversationStatus_Closed:function (data) {
+        if (data['html'] != undefined) {
+            this.updateChatContainerWithHTML("#visitorChat_container", data['html']);
+            WDN.jQuery("#visterChat_conversation").append("<div class='visitorChat_center'></div>");
+        }
+
         clearTimeout(VisitorChat.loopID);
+
         var html = '<div class="chat_notify" id="visitorChat_closed">This conversation has ended.</div>';
         this.updateChatContainerWithHTML(".visitorChat_center", html);
+
+        if (data['messages'] == undefined) {
+            return true;
+        }
+
+        this.appendMessages(data['messages']);
     },
 
     /**

--- a/www/js/VisitorChat/Operator.js
+++ b/www/js/VisitorChat/Operator.js
@@ -439,6 +439,12 @@ var VisitorChat_Chat = VisitorChat_ChatBase.extend({
         WDN.jQuery('#visitorChat_closed').siblings().css({'opacity':'0.1'})
         //set the opacity of current item to full, and add the effect class
         WDN.jQuery('#visitorChat_closed').css({'opacity':'1.0'});
+
+        if (data['messages'] == undefined) {
+            return true;
+        }
+
+        this.appendMessages(data['messages']);
     },
 
     updateConversationList:function () {


### PR DESCRIPTION
The conversation might be loaded after it has been closed and the client moves to another page, so send messages and load them into the chat so that the client can still see them until the client logs out.
