### PR TITLE
Fallback email fixes

### DIFF
--- a/src/UNL/VisitorChat/Conversation/Email.php
+++ b/src/UNL/VisitorChat/Conversation/Email.php
@@ -30,15 +30,16 @@ class Email
     
     function setReplyTo($replyTo = "") {
         if (!$replyTo == "") {
-            $this->replyTo = $replyTo;
+            $this->reply_to = $replyTo;
             
             return true;
         }
         
         $client = $this->conversation->getClient();
-        
+
         if (\Validate::email($client->email)) {
-            $this->replyTo = $client->email;
+            $this->reply_to = $client->email;
+
         }
         
         return true;
@@ -112,8 +113,8 @@ class Email
     public function generateHeaders()
     {
         return array(
-          'From'     => $this->reply_to,
-          'Reply-To' => $this->from,
+          'From'     => $this->from,
+          'Reply-To' => $this->reply_to,
           'To'       => $this->generateToString(),
           'Subject'  => $this->subject);
     }

--- a/src/UNL/VisitorChat/Conversation/FallbackEmail.php
+++ b/src/UNL/VisitorChat/Conversation/FallbackEmail.php
@@ -3,5 +3,11 @@ namespace UNL\VisitorChat\Conversation;
 
 class FallbackEmail extends Email
 {
-    
+    function __construct(\UNL\VisitorChat\Conversation\Record $conversation, $to = array(), $options = array())
+    {
+        parent::__construct($conversation, $to, $options);
+
+        //Set the reply to
+        $this->setReplyTo();
+    }
 }

--- a/www/templates/email/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
+++ b/www/templates/email/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
@@ -6,12 +6,17 @@
         <?php 
         $client = $context->conversation->getClient();
         $response = "";
-        if ($context->conversation->email_fallback) {
+        if ($context->conversation->email_fallback && !empty($client->email)) {
             $response = "The user requests a response <br />";
         }
         ?>
         Message from <?php echo $client->name ?><br />
         IP: <?php echo $client->ip ?><br />
+        <?php
+        if (!empty($client->email)) {
+            echo "Email: " . $client->email . " <br />";
+        }
+        ?>
         at <?php echo $context->conversation->initial_url; ?> <br /> <?php echo $response;?>
     </p>
 </div>


### PR DESCRIPTION
Correctly set the reply-to header for fallback emails, display "the user requests a response" only when they actually request a response and provide the client's email address in the fallback email.  fixes #71
