### PR TITLE
Fix a failing unit test for the login function

### DIFF
--- a/src/UNL/VisitorChat/Conversation/Email/Record.php
+++ b/src/UNL/VisitorChat/Conversation/Email/Record.php
@@ -60,7 +60,7 @@ class Record extends \Epoch\Record
         //Set the date_sent field
         $this->date_sent = \UNL\VisitorChat\Controller::epochToDateTime();
 
-        parent::insert();
+        return parent::insert();
     }
 
     public static function recordSentEmail($to, $from, $replyTo, $subject, $userId, $conversationId)

--- a/tests/Data/FreshDB.sql
+++ b/tests/Data/FreshDB.sql
@@ -144,6 +144,33 @@ CREATE TABLE IF NOT EXISTS `users` (
   KEY `fk_users_Invitations1` (`Invitations_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=2 ;
 
+-- -----------------------------------------------------
+-- Table `emails`
+-- -----------------------------------------------------
+CREATE  TABLE IF NOT EXISTS `emails` (
+  `id` INT NOT NULL AUTO_INCREMENT ,
+  `to` VARCHAR(255) NOT NULL ,
+  `from` VARCHAR(255) NOT NULL ,
+  `subject` TEXT NOT NULL ,
+  `date_sent` DATETIME NOT NULL ,
+  `conversations_id` INT NOT NULL ,
+  `reply_to` VARCHAR(255) NOT NULL ,
+  `users_id` INT NOT NULL ,
+  PRIMARY KEY (`id`) ,
+  INDEX `fk_emails_conversations1` (`conversations_id` ASC) ,
+  INDEX `fk_emails_users1` (`users_id` ASC) ,
+  CONSTRAINT `fk_emails_conversations1`
+    FOREIGN KEY (`conversations_id` )
+    REFERENCES `visitorchatapp`.`conversations` (`id` )
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_emails_users1`
+    FOREIGN KEY (`users_id` )
+    REFERENCES `visitorchatapp`.`users` (`id` )
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
 --
 -- Dumping data for table `users`
 --

--- a/tests/Data/pendingAssignment.sql
+++ b/tests/Data/pendingAssignment.sql
@@ -149,6 +149,33 @@ CREATE TABLE IF NOT EXISTS `users` (
   UNIQUE KEY `uid_UNIQUE` (`uid`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=4 ;
 
+-- -----------------------------------------------------
+-- Table `emails`
+-- -----------------------------------------------------
+CREATE  TABLE IF NOT EXISTS `emails` (
+  `id` INT NOT NULL AUTO_INCREMENT ,
+  `to` VARCHAR(255) NOT NULL ,
+  `from` VARCHAR(255) NOT NULL ,
+  `subject` TEXT NOT NULL ,
+  `date_sent` DATETIME NOT NULL ,
+  `conversations_id` INT NOT NULL ,
+  `reply_to` VARCHAR(255) NOT NULL ,
+  `users_id` INT NOT NULL ,
+  PRIMARY KEY (`id`) ,
+  INDEX `fk_emails_conversations1` (`conversations_id` ASC) ,
+  INDEX `fk_emails_users1` (`users_id` ASC) ,
+  CONSTRAINT `fk_emails_conversations1`
+    FOREIGN KEY (`conversations_id` )
+    REFERENCES `visitorchatapp`.`conversations` (`id` )
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_emails_users1`
+    FOREIGN KEY (`users_id` )
+    REFERENCES `visitorchatapp`.`users` (`id` )
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
 --
 -- Dumping data for table `users`
 --


### PR DESCRIPTION
return the result of the parent insert function in the conversation email record.  Update the sql database to include the new emails table.
