### PR TITLE
Placeholder fix for IE

### DIFF
--- a/www/js/VisitorChat/ChatBase.js
+++ b/www/js/VisitorChat/ChatBase.js
@@ -108,6 +108,8 @@ var VisitorChat_ChatBase = Class.extend({
      * flow of the chat.
      */
     start:function () {
+        this.initWatchers();
+        
         this.chatOpened = true;
 
         clearTimeout(VisitorChat.loopID);

--- a/www/js/VisitorChat/Remote.js
+++ b/www/js/VisitorChat/Remote.js
@@ -29,6 +29,12 @@ var VisitorChat_Chat = VisitorChat_ChatBase.extend({
         WDN.jQuery("#visitorChat_footerHeader").css({'display':'none'});
         WDN.jQuery("#visitorChat_email").hide();
         WDN.jQuery("#visitorChat_container #visitorChat_email_fallback_text").html('If no operators are available,&nbsp;I would like to receive an email.');
+        
+        //Due to IE, make sure that we clear the value of the input if it equals the placeholder value
+        if (WDN.jQuery("#visitorChat_messageBox").val() == WDN.jQuery("#visitorChat_messageBox").attr("placeholder")) {
+            WDN.jQuery("#visitorChat_messageBox").val('');
+        }
+        
         WDN.jQuery("#visitorChat_messageBox").attr("placeholder", "How can we assist you?");
         this.start();
     },
@@ -243,6 +249,7 @@ var VisitorChat_Chat = VisitorChat_ChatBase.extend({
         WDN.jQuery("#visitorChat_failedOptions_yes").click(function() {
             VisitorChat.stop(function(){
                 WDN.jQuery("#visitorChat_name").val(VisitorChat.clientName);
+                
                 WDN.jQuery("#visitorChat_messageBox").val(VisitorChat.initialMessage);
                 WDN.jQuery("#visitorChat_email").focus();
                 WDN.jQuery("#visitorChat_messageBox").keyup();


### PR DESCRIPTION
IE does not support placeholders, so if the current value of the message box is equal to the current value of the placeholder, set the value to an empty string before updating the value of the placeholder.  If we don't do this, the placeholder plugin will assume that the user has entered text.

fixes #159
