### PR TITLE
Bugfix: only display conversations for the answering site.

### DIFF
--- a/src/UNL/VisitorChat/Conversation/RecordList.php
+++ b/src/UNL/VisitorChat/Conversation/RecordList.php
@@ -37,7 +37,7 @@ class RecordList extends \Epoch\RecordList
         $options['sql'] = "SELECT conversations.id
                            FROM conversations
                            LEFT JOIN assignments ON (conversations.id = assignments.conversations_id)
-                           WHERE assignments.answering_site LIKE '%" . self::escapeString($url) . "%'
+                           WHERE assignments.answering_site = '" . self::escapeString($url) . "'
                            GROUP BY conversations.id
                            ORDER BY conversations.date_created ASC";
         


### PR DESCRIPTION
The url given should be the exact URL for the answering site.
