### PR TITLE
Auth updates

### DIFF
--- a/src/UNL/VisitorChat/User/Edit.php
+++ b/src/UNL/VisitorChat/User/Edit.php
@@ -6,8 +6,10 @@ class Edit extends \UNL\VisitorChat\User\Record
     function __construct($options = array())
     {
         \UNL\VisitorChat\Controller::$pagetitle = "User Settings";
-        
-        \UNL\VisitorChat\Controller::requireLogin();
+
+        if (!\UNL\VisitorChat\User\Service::getCurrentUser()) {
+            throw new \Exception("You must be logged in to do this.", 401);
+        }
 
         if (isset($options['id']) && $object = \UNL\VisitorChat\User\Record::getByID($options['id'])) {
             $this->synchronizeWithArray($object->toArray());
@@ -18,10 +20,6 @@ class Edit extends \UNL\VisitorChat\User\Record
     
     function handlePost($post = array())
     {
-        if (!\UNL\VisitorChat\User\Service::getCurrentUser()) {
-            throw new \Exception("You must be logged in to do this.", 401);
-        }
-
         if (\UNL\VisitorChat\User\Service::getCurrentUser()->id !== $this->id) {
             throw new \Exception("you do not have permission to edit this.", 403);
         }

--- a/src/UNL/VisitorChat/User/SiteList.php
+++ b/src/UNL/VisitorChat/User/SiteList.php
@@ -7,6 +7,10 @@ class SiteList
     
     function __construct($options = array())
     {
+        if (!\UNL\VisitorChat\User\Service::getCurrentUser()) {
+            throw new \Exception("You must be logged in to do this.", 401);
+        }
+        
         \UNL\VisitorChat\Controller::requireOperatorLogin();
         
         $user = \UNL\VisitorChat\User\Service::getCurrentUser();

--- a/www/js/VisitorChat/Operator.js
+++ b/www/js/VisitorChat/Operator.js
@@ -669,6 +669,12 @@ var VisitorChat_Chat = VisitorChat_ChatBase.extend({
         WDN.jQuery.ajax({
             type:"GET",
             url:this.serverURL + "user/sites?format=json",
+            statusCode: {
+                //Did our session expire?
+                401: function() {
+                    window.location.reload(); //reload the page
+                }
+            },
             success:WDN.jQuery.proxy(function (data) {
                 var offline = new Array();
 


### PR DESCRIPTION
Throw 401 errors when an operator is no longer authenticated so that the js knows to re-auth.
