### PR TITLE
Correct issue where the transcript form was not visible after a page refresh

### DIFF
--- a/www/js/VisitorChat/ChatBase.js
+++ b/www/js/VisitorChat/ChatBase.js
@@ -415,7 +415,7 @@ var VisitorChat_ChatBase = Class.extend({
     onConversationStatus_Closed:function (data) {
         if (data['html'] != undefined) {
             this.updateChatContainerWithHTML("#visitorChat_container", data['html']);
-            WDN.jQuery("#clientChat").append("<div class='visitorChat_center'></div>");
+            WDN.jQuery("#visitorChat_container").append("<div class='visitorChat_center'></div>");
         }
 
         clearTimeout(VisitorChat.loopID);


### PR DESCRIPTION
Append the `.visitorChat_center` div to the `#visitorChat_container` div instead of appending it ot the `#clientChat` div.  The `#clientChat` div is not present for clients, it is only present for operators.
