### PR TITLE
Don't allow the same user status to be posted twice in a row.

### DIFF
--- a/src/UNL/VisitorChat/User/Record.php
+++ b/src/UNL/VisitorChat/User/Record.php
@@ -189,6 +189,11 @@ class Record extends \Epoch\Record
      */
     function setStatus($status, $reason = "USER") 
     {
+        //Don't allow the same status to be posted twice in a row. (Could happen when logging in/out).
+        if ($this->status == $status) {
+            return true;
+        }
+        
         //Store the current status in this record (for caching and easy access).
         $this->status        = $status;
         $this->status_reason = $reason;


### PR DESCRIPTION
This could happen when logging in/our.  When a user logs in or out, their status is auto set to 'BUSY'.  This prevents two 'BUSY' statuses from being posted in a row.
