### PR TITLE
Create a default status because the status field can not be null

### DIFF
--- a/src/UNL/VisitorChat/User/ClientLogin.php
+++ b/src/UNL/VisitorChat/User/ClientLogin.php
@@ -68,6 +68,7 @@ class ClientLogin extends \UNL\VisitorChat\User\Record
         $user->type         = 'client';
         $user->max_chats    = 3;
         $user->date_updated = \UNL\VisitorChat\Controller::epochToDateTime();
+        $user->status = 'BUSY';
         
         $user->save();
 

--- a/src/UNL/VisitorChat/User/OperatorLogin.php
+++ b/src/UNL/VisitorChat/User/OperatorLogin.php
@@ -58,7 +58,7 @@ class OperatorLogin
                 }
             }
         }
-
+        $user->status = 'BUSY';
         $user->date_updated = \UNL\VisitorChat\Controller::epochToDateTime();
         
         $user->save();


### PR DESCRIPTION
temp fix.
