### PR TITLE
Remove the current message form and ensure that the visitorChat_closed div will be created

### DIFF
--- a/www/js/VisitorChat/ChatBase.js
+++ b/www/js/VisitorChat/ChatBase.js
@@ -415,9 +415,10 @@ var VisitorChat_ChatBase = Class.extend({
     onConversationStatus_Closed:function (data) {
         if (data['html'] != undefined) {
             this.updateChatContainerWithHTML("#visitorChat_container", data['html']);
-            WDN.jQuery("#visitorChat_container").append("<div class='visitorChat_center'></div>");
         }
 
+        WDN.jQuery("#visitorChat_container").append("<div class='visitorChat_center'></div>");
+        
         clearTimeout(VisitorChat.loopID);
 
         var html = '<div class="chat_notify" id="visitorChat_closed"><h2>This conversation has ended.</h2></div>';

--- a/www/js/VisitorChat/Remote.js
+++ b/www/js/VisitorChat/Remote.js
@@ -465,6 +465,8 @@ var VisitorChat_Chat = VisitorChat_ChatBase.extend({
         this.confirmationHTML = data['confirmationHTML'];
 
         WDN.jQuery("#visitorChat_chatBox").height("150px");
+        
+        WDN.jQuery("#visitorChat_messageForm").remove();
 
         WDN.jQuery("#visitorChat_closed").append(data['confirmationHTML'])
 


### PR DESCRIPTION
This fixes a bug where confirmation emails were not being sent correctly on the second attempt.
