### PR TITLE
Minor spacing adjustment

### DIFF
--- a/www/css/VisitorChat/4.0/client.css
+++ b/www/css/VisitorChat/4.0/client.css
@@ -63,7 +63,7 @@
 #visitorChat_header {
     border-top-right-radius: 5px;
     border-top-left-radius: 5px;
-    height: 24px;
+    height: 26px;
     padding: 4px 5px 0px 5px;
     width: 214px;
     outline:none;


### PR DESCRIPTION
The chat tab looks a little squished down towards the bottom of the browser. This change adds two pixels to the height of the chat tab, so the spacing below "Let's Talk" appears equal to that above.

Before:
![screen shot 2013-08-14 at 3 43 01 pm](https://f.cloud.github.com/assets/92284/965066/3f6e540a-0523-11e3-9bc7-025162765e24.png)

After:
![screen shot 2013-08-14 at 3 42 49 pm](https://f.cloud.github.com/assets/92284/965072/4facfef2-0523-11e3-9504-32129354717c.png)
