### PR TITLE
Fix location in emails

### DIFF
--- a/scripts/handleSearchingEmailConversations.php
+++ b/scripts/handleSearchingEmailConversations.php
@@ -10,7 +10,7 @@ if (file_exists(dirname(dirname(__FILE__)) . '/config.inc.php')) {
     require dirname(dirname(__FILE__)) . '/config.sample.php';
 }
 
-\UNL\VisitorChat\Controller::$environment = "PHPT";
+\UNL\VisitorChat\Controller::$environment = "CLI";
 $app = new \UNL\VisitorChat\Controller();
 
 foreach (\UNL\VisitorChat\Conversation\RecordList::getAllSearchingEmailConversations() as $conversation) {

--- a/src/UNL/VisitorChat/Controller.php
+++ b/src/UNL/VisitorChat/Controller.php
@@ -113,6 +113,11 @@ class Controller extends \Epoch\Controller
      */
     public static function requireClientLogin()
     {
+        if (self::$environment == "CLI") {
+            //Assume a client permission is always granted in CLI
+            return true;
+        }
+        
         if (!isset($_SESSION['id'])) {
             self::redirect(\UNL\VisitorChat\Controller::$URLService->generateSiteURL("clientLogin", true, true));
         }
@@ -352,7 +357,12 @@ class Controller extends \Epoch\Controller
     
     public static function redirect($url, $exit = true)
     {
-        if (self::$environment == "PHPT" || self::$environment == "CLI") {
+        if (self::$environment == "CLI") {
+            //Don't echo in CLI, this could expose the url in things like emails
+            return true;
+        }
+        
+        if (self::$environment == "PHPT") {
             echo "Location: " . $url  . PHP_EOL;
             return true;
         }


### PR DESCRIPTION
This is a rare case where the client or operator didn't close the conversation and the CLI scripts closed it due to inactivity, and the client would have had to supplied their email address before starting the conversation.  The CLI scripts echo redirects for unit test reasons, which was placing the redirect URL in emails.    This change makes it so that only the "PHPT" environment will echo the redirect.

This change also short circuits the `requireClientLogin()` method in the CLI environment because that level of permission should be assumed in command line scripts.