### PR TITLE
Fix unwanted space added to speech balloon shape

### DIFF
--- a/www/css/VisitorChat/4.0/client.css
+++ b/www/css/VisitorChat/4.0/client.css
@@ -25,9 +25,8 @@
 #visitorChat:after {
   content: '';
   position: absolute;
-  bottom: 0;
+  top: 100%;
   right: 1.333em;
-  transform: translateY(100%);
   z-index: 299;
   border-style: solid;
   border-width: .75em 0 .75em .75em;

--- a/www/less/client.less
+++ b/www/less/client.less
@@ -28,9 +28,8 @@
     &:after {
         content: '';
         position: absolute;
-        bottom: 0;
+        top: 100%;
         right: 1.333em;
-        transform: translateY(100%);
         z-index: 299;
         border-style: solid;
         border-width: .75em 0 .75em .75em;


### PR DESCRIPTION
After updating Chrome, an unwanted space in the chat widget has appeared. It is located above the pseudo element used to create the triangle in the speech balloon shape:

<img width="140" alt="screen shot 2017-05-08 at 9 38 30 am" src="https://cloud.githubusercontent.com/assets/5385125/25809419/8a0cf3d6-33d2-11e7-8cab-b25e193b1dd1.png">

My hunch is that this is caused by Chrome's [recently added support for subpixel layout of borders](https://chromium.googlesource.com/chromium/src/+/934becac5daa91ea979fb66e4ae21761ca11ebc9).

By replacing `bottom: 0;` and `transform: translateY(100%);` with `top: 100%;`, the unwanted space goes away. So does an extra line (or two, counting vendor prefixes) of code!