### PR TITLE
Update utility classes used in chat

### DIFF
--- a/www/js/VisitorChat/5.0/Client.js.php
+++ b/www/js/VisitorChat/5.0/Client.js.php
@@ -665,7 +665,7 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
                         "<span id='visitorChat_header_text'>Email Us</span>" +
                     "</div>" +
                     "<div id='visitor-chat-header-options'>" +
-                        "<button id='visitorChat_logout' aria-label='close and log out of chat'>" +
+                        "<button class='dcf-pt-1 dcf-pl-4 dcf-pb-1 dcf-pr-5' id='visitorChat_logout' aria-label='close and log out of chat'>" +
                             "<span class='wdn-icon-cancel'></span>" +
                         "</button>" +
                     "</div>" +

--- a/www/js/VisitorChat/5.0/Client.js.php
+++ b/www/js/VisitorChat/5.0/Client.js.php
@@ -674,7 +674,7 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
 
             $('nav.dcf-pin-bottom').append("" +
                 '<button class="dcf-nav-toggle-btn dcf-nav-toggle-btn-chat dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-scarlet" id="dcf-mobile-toggle-chat" aria-expanded="false">' +
-                    '<svg class="dcf-txt-sm dcf-mb-1 dcf-h-6 dcf-w-6 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">' +
+                    '<svg class="dcf-txt-sm dcf-h-6 dcf-w-6 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">' +
                         '<path d="M1.4 23.2c-.1 0-.3-.1-.4-.2-.1-.2-.2-.4-.1-.6l2.4-4.8C1.2 15.9 0 13.5 0 10.9 0 5.4 5.4 1 12 1s12 4.4 12 9.9-5.4 9.9-12 9.9c-1.4 0-2.7-.2-4-.6l-6.4 3h-.2zM12 2C5.9 2 1 6 1 10.9c0 2.4 1.2 4.6 3.3 6.3.2.1.2.4.1.6l-1.9 3.9 5.3-2.5c.1-.1.2-.1.4 0 1.2.4 2.5.6 3.9.6 6.1 0 11-4 11-8.9S18.1 2 12 2z"></path>' +
                     '</svg>' +
                     '<span class="dcf-nav-toggle-label dcf-mt-1 dcf-txt-2xs">Email Us</span>' +

--- a/www/templates/default/UNL/VisitorChat/Conversation/Email/ConfirmationEmail.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Conversation/Email/ConfirmationEmail.tpl.php
@@ -1,6 +1,6 @@
 <div id='visitorChat_confirmationContainer' tabindex="-1">
     Enter your email address to receive a transcript of this conversation.
-    <form id='visitorChat_confirmationEmailForm' action="<?php echo UNL\VisitorChat\Controller::$URLService->generateSiteURL('conversation/' . $context->conversation->id . '/sendConfirmEmail', true, true)?>" class='unl_visitorchat_form' method="POST">
+    <form id='visitorChat_confirmationEmailForm' action="<?php echo UNL\VisitorChat\Controller::$URLService->generateSiteURL('conversation/' . $context->conversation->id . '/sendConfirmEmail', true, true)?>" class='unl_visitorchat_form unl-darker-gray' method="POST">
         <fieldset>
             <legend>Email Address</legend>
             <ul>
@@ -12,6 +12,6 @@
         </fieldset>
 
         <input type='hidden' name='conversations_id' value='<?php echo $context->conversation->id ?>'/>
-        <input id='visitorChat_confirmEmail_submit' class="wdn-button wdn-button-triad" type="submit" value="Submit" name="visitorChat_confirmEmail_submit" />
+        <input id='visitorChat_confirmEmail_submit' class="dcf-btn dcf-btn-primary" type="submit" value="Submit" name="visitorChat_confirmEmail_submit" />
     </form>
 </div>

--- a/www/templates/default/UNL/VisitorChat/Message/Edit.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Message/Edit.tpl.php
@@ -1,5 +1,5 @@
 <div id="visitorChat_is_typing"></div>
-<form class='unl_visitorchat_form' id='visitorChat_messageForm' name="input" action="<?php echo $context->getEditURL();?>" method="post">
+<form class='unl_visitorchat_form unl-darker-gray' id='visitorChat_messageForm' name="input" action="<?php echo $context->getEditURL();?>" method="post">
     <fieldset>
           <ul>
             <li class='visitorChat_center'>
@@ -10,5 +10,5 @@
     </fieldset>
     <input type="hidden" name="conversations_id" value='<?php echo $context->conversations_id ?>'/>
     <input type="hidden" name="_class" value='<?php echo get_class($context->getRawObject()); ?>'/>
-    <input id='visitorChat_message_submit' class="wdn-button wdn-button-triad" type="submit" value="Submit" name="visitorChat_message_submit" />
+    <input id='visitorChat_message_submit' class="dcf-btn dcf-btn-primary" type="submit" value="Submit" name="visitorChat_message_submit" />
 </form>

--- a/www/templates/default/UNL/VisitorChat/User/ClientLogin.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/User/ClientLogin.tpl.php
@@ -1,4 +1,4 @@
-<form id='visitorchat_clientLogin' class='unl_visitorchat_form' name='input' method="post" action="<?php echo \UNL\VisitorChat\Controller::$url;?>clientLogin" style="display: block">
+<form id='visitorchat_clientLogin' class='unl_visitorchat_form unl-darker-gray' name='input' method="post" action="<?php echo \UNL\VisitorChat\Controller::$url;?>clientLogin" style="display: block">
     <fieldset><legend id="visitorChat_footerHeader">Comments for this page</legend>
         <ul>
             <li class="visitorChat_center">
@@ -22,5 +22,5 @@
     <input type="hidden" name="initial_url" id="initial_url" value=""/>
     <input type="hidden" name="initial_pagetitle" id="initial_pagetitle" value=""/>
     <input id="visitorChat_login_chatmethod" type="hidden" name="method" value="EMAIL" />
-    <input id='visitorChat_login_submit' class="wdn-button wdn-button-triad" type="submit" value="Submit" name="visitorChat_login_submit" />
+    <input id='visitorChat_login_submit' class="dcf-btn dcf-btn-primary" type="submit" value="Submit" name="visitorChat_login_submit" />
 </form>


### PR DESCRIPTION
- Remove margin-bottom from chat icon for consistent spacing with other toggle buttons.
- Add padding utilities for ‘close’ button.
- Add color utility and button classes. Fixes https://github.com/unl/wdntemplates/issues/1234