### PR TITLE
Add Third Party cookie support via samesite

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -27,7 +27,12 @@ require_once __DIR__ . '/vendor/autoload.php';
  * php related settings
  */
 //Session life in seconds.
-ini_set("session.gc_maxlifetime", 7200); 
+ini_set("session.gc_maxlifetime", 7200);
+
+// Support third-party cookie to support chats on affiliate sites
+// NOTE for DEV site without HTTPS set samesite to 'strict' or 'lax' and secure to false;
+ini_set("session.cookie_samesite", 'none');
+ini_set("session.cookie_secure", true);
 
 ini_set('display_errors', false);
 

--- a/www/js/VisitorChat/5.0/Client.js.php
+++ b/www/js/VisitorChat/5.0/Client.js.php
@@ -30,6 +30,10 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
         lexruntime: new AWS.LexRuntime(),
         sessionAttributes: {},
 
+        setSessionCookie(name, value, expiresInSeconds, path) {
+          WDN.setCookie(name, value, expiresInSeconds, path, null, 'none', true);
+        },
+
         isChatbotAvailable: function() {
           return this.lexruntime && this.getChatbotID() && this.getChatbotName();
         },
@@ -303,7 +307,7 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
                 analytics.callTrackEvent('WDN Chat', 'Response', 'Received', difference);
 
                 //Set a cookie so that we don't call this if we have to reload the chat (page refresh or move to another page).
-                WDN.setCookie('UNL_Visitorchat_FirstOperatorResponse', difference, null, '/');
+                this.setSessionCookie('UNL_Visitorchat_FirstOperatorResponse', difference, null, '/');
             }
         },
 
@@ -704,7 +708,7 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
 
             //Set a cookie.
             date = new Date();
-            WDN.setCookie('UNL_Visitorchat_Start', (Math.round(date.getTime() / 1000)), null, '/');
+            this.setSessionCookie('UNL_Visitorchat_Start', (Math.round(date.getTime() / 1000)), null, '/');
 
             //Mark as started
             analytics.callTrackEvent('WDN Chat', 'Started');
@@ -804,7 +808,7 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
 
             //set the cookie (IE ONLY).
             if (navigator.userAgent.indexOf("MSIE") !== -1) {
-                WDN.setCookie('UNL_Visitorchat_Session', phpsessid, null, '/');
+                this.setSessionCookie('UNL_Visitorchat_Session', phpsessid, null, '/');
             }
         },
 
@@ -904,9 +908,9 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
 
         deleteAnalyticsCookies: function() {
             //Delete the current cookie.
-            WDN.setCookie('UNL_Visitorchat_Start', '0', -1, '/');
-            WDN.setCookie('UNL_Visitorchat_Session', '0', -1, '/');
-            WDN.setCookie('UNL_Visitorchat_FirstOperatorResponse', '0', -1, '/');
+            this.setSessionCookie('UNL_Visitorchat_Start', '0', -1, '/');
+            this.setSessionCookie('UNL_Visitorchat_Session', '0', -1, '/');
+            this.setSessionCookie('UNL_Visitorchat_FirstOperatorResponse', '0', -1, '/');
         },
 
         closeChatContainer: function() {


### PR DESCRIPTION
Note: This update is currently dependent on the WDN update for WDN.setCookie.

An alternative would be to move all of the logic of WDN.setCookie into the new client setSessionCookie function.