### PR TITLE
Use Cookies to track CORS chat sessions

### DIFF
--- a/www/js/VisitorChat/4.0/ChatBase.js.php
+++ b/www/js/VisitorChat/4.0/ChatBase.js.php
@@ -71,6 +71,8 @@ var VisitorChat_ChatBase = Class.extend({
 
     version: 4.0,
 
+    nonCORSDomain: 'unl.edu',
+
     config: {},
 
     //timeout for the is_typing status
@@ -131,8 +133,15 @@ var VisitorChat_ChatBase = Class.extend({
         });
     },
 
+    usePhpSessIdCookie: function() {
+      var domainName = window.location.hostname;
+      var nonCORSDomainLength = this.nonCORSDomain.length;
+      // Use cookie if MSIE browser or CORSDomain
+      return navigator.userAgent.indexOf("MSIE") !== -1 || (domainName.length >= nonCORSDomainLength && domainName.substr(domainName.length-nonCORSDomainLength, nonCORSDomainLength) != this.nonCORSDomain);
+    },
+
     getURLSessionParam: function() {
-        if (navigator.userAgent.indexOf("MSIE") == -1) {
+        if (!this.usePhpSessIdCookie()) {
             return '';
         }
 

--- a/www/js/VisitorChat/4.0/Client.js.php
+++ b/www/js/VisitorChat/4.0/Client.js.php
@@ -634,8 +634,8 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
         updatePHPSESSID:function (phpsessid) {
             this.phpsessid = phpsessid;
 
-            //set the cookie (IE ONLY).
-            if (navigator.userAgent.indexOf("MSIE") !== -1) {
+            //set the cookie (IE ONLY) or CORS Domain.
+            if (this.usePhpSessIdCookie()) {
                 WDN.setCookie('UNL_Visitorchat_Session', phpsessid, null, '/');
             }
         },

--- a/www/js/VisitorChat/5.0/ChatBase.js.php
+++ b/www/js/VisitorChat/5.0/ChatBase.js.php
@@ -82,6 +82,8 @@ var VisitorChat_ChatBase = Class.extend({
 
     version: 5.0,
 
+    nonCORSDomain: 'unl.edu',
+
     config: {},
 
     //timeout for the is_typing status
@@ -142,8 +144,15 @@ var VisitorChat_ChatBase = Class.extend({
         });
     },
 
+    usePhpSessIdCookie: function() {
+      var domainName = window.location.hostname;
+      var nonCORSDomainLength = this.nonCORSDomain.length;
+      // Use cookie if MSIE browser or CORSDomain
+      return navigator.userAgent.indexOf("MSIE") !== -1 || (domainName.length >= nonCORSDomainLength && domainName.substr(domainName.length-nonCORSDomainLength, nonCORSDomainLength) != this.nonCORSDomain);
+    },
+
     getURLSessionParam: function() {
-        if (navigator.userAgent.indexOf("MSIE") == -1) {
+        if (!this.usePhpSessIdCookie()) {
             return '';
         }
 

--- a/www/js/VisitorChat/5.0/Client.js.php
+++ b/www/js/VisitorChat/5.0/Client.js.php
@@ -806,8 +806,8 @@ require(['jquery', 'idm', 'analytics'], function($, idm, analytics) {
         updatePHPSESSID:function (phpsessid) {
             this.phpsessid = phpsessid;
 
-            //set the cookie (IE ONLY).
-            if (navigator.userAgent.indexOf("MSIE") !== -1) {
+            //set the cookie (IE ONLY) or CORS Domain.
+            if (this.usePhpSessIdCookie()) {
                 this.setSessionCookie('UNL_Visitorchat_Session', phpsessid, null, '/');
             }
         },


### PR DESCRIPTION
This update allows non unl.edu sites like https://nufcu.org/ to use the UNL Chat.  Without the fix the session ids never sync.

Please review the code, once approved I will test PR branch on production site before merging to verify the issue is resolved on production.  It works on my dev environment.