### PR TITLE
Fix conservation share display and functionality.

### DIFF
--- a/src/UNL/VisitorChat/Conversation/Share.php
+++ b/src/UNL/VisitorChat/Conversation/Share.php
@@ -37,18 +37,21 @@ class Share extends \UNL\VisitorChat\Conversation\Record
         if (!isset($post['method']) || !in_array($post['method'], array('invite'))) {
             throw new \Exception('A valid method was not given.', 400);
         }
-        
-        if (!isset($post['to'])) {
+
+        if (!isset($post['to']) || strtolower($post['to']) === 'default') {
             throw new \Exception('No one was specified to share this conversation with.', 400);
         }
         
         switch ($post['method']) {
-            case 'invite': 
+            case 'invite':
                 //Start a new invitation.
                 if (!\UNL\VisitorChat\Invitation\Record::createNewInvitation($this->id, $post['to'], \UNL\VisitorChat\User\Service::getCurrentUser()->id)) {
                     throw new \Exception('Failed to send invite', 500);
                 }
                 break;
+
+	        default:
+		        throw new \Exception('A valid method was not given.', 400);
         }
         
         \Epoch\Controller::redirect(\UNL\VisitorChat\Controller::$URLService->generateSiteURL("success", true));

--- a/www/js/VisitorChat/5.0/Operator.js.php
+++ b/www/js/VisitorChat/5.0/Operator.js.php
@@ -286,15 +286,12 @@ require(['jquery', 'jqueryui'], function($) {
                     }
                 },
                 success:$.proxy(function (data) {
-
-                    $("#visitorChat_brightBox").html(data);
-                    this.showBrightBox();
-                    this.loadShareWatchers();
-                    //start a new dialog box.
+                    // Populate content in DCF modal
+                    $("#share-conversation-modal-content").html(data);
+                    // Trigger click on hidden button to open DCF Modal
+                    $(".share-conversation-modal-toggle-btn").click();
                 }, this)
             });
-
-            $('#visitorChat_brightBox').height('350px');
         },
 
         loadShareWatchers:function () {

--- a/www/js/VisitorChat/5.0/Operator.js.php
+++ b/www/js/VisitorChat/5.0/Operator.js.php
@@ -273,6 +273,12 @@ require(['jquery', 'jqueryui'], function($) {
         },
 
         openShareWindow:function () {
+            // Add loading to DCF Modal
+            $("#share-conversation-modal-content").html('<progress></progress>');
+
+            // Trigger click on hidden button to open DCF Modal
+            $(".share-conversation-modal-toggle-btn").click();
+
             //Update the Client List
             $.ajax({
                 url:this.serverURL + "conversation/" + this.conversationID + "/share?format=partial",
@@ -285,12 +291,13 @@ require(['jquery', 'jqueryui'], function($) {
                         window.location.reload(); //reload the page
                     }
                 },
-                success:$.proxy(function (data) {
+                success: function(data) {
                     // Populate content in DCF modal
                     $("#share-conversation-modal-content").html(data);
-                    // Trigger click on hidden button to open DCF Modal
-                    $(".share-conversation-modal-toggle-btn").click();
-                }, this)
+                },
+                error: function(xhr, status, error) {
+                  $("#share-conversation-modal-content").html('<p class="dcf-txt-lg">Error: Loading of share options failed.</p>');
+                }
             });
         },
 

--- a/www/templates/default/UNL/VisitorChat/Conversation/Share.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Conversation/Share.tpl.php
@@ -1,21 +1,37 @@
-<h2>Share this conversation</h2>
-<form class="dcf-form" id="shareForm" name="share action="<?php UNL\VisitorChat\Controller::$URLService->generateSiteURL('conversation/' . $context->id . '/share', true)?>" method="POST">
-    <fieldset class="dcf-m-0 dcf-p-0 dcf-b-0">
-        <legend>Select sharing method</legend>
-        <ul class="dcf-list-bare">
-            <li><input class="dcf-input-control" type="radio" name="method" value="invite" checked="checked">Invite to conversation</li>
-        </ul>
-    </fieldset>
-    <fieldset class="dcf-m-0 dcf-p-0 dcf-b-0">
-        <legend>Select who you want to share with</legend>
-        <fieldset>
-            <?php
-            //Display a list of all sites next.
-            $list = \UNL\VisitorChat\Controller::$registryService->getAllSites();
-
-            echo $savvy->render($list, 'UNL/VisitorChat/Conversation/ShareList.tpl.php');
-            ?>
-        </fieldset>
-    </fieldset>
-    <input class="dcf-btn dcf-btn-primary submit" type="submit" value="Submit">
+<form class="dcf-form" id="shareForm" name="share" action="<?php echo UNL\VisitorChat\Controller::$URLService->generateSiteURL('conversation/' . $context->id . '/share', false, false)?>" method="POST">
+    <?php // only one method for here, so use hidden input ?>
+    <input type="hidden" name="method" value="invite">
+    <?php
+        //Display a list of all sites next.
+        $list = \UNL\VisitorChat\Controller::$registryService->getAllSites();
+        echo $savvy->render($list, 'UNL/VisitorChat/Conversation/ShareList.tpl.php');
+    ?>
+    <div class="dcf-input-checkbox">
+        <input id="include-inactive-share-options" type="checkbox" value="0">
+        <label for="include-inactive-share-options">Include inactive operators <span class="dcf-form-help">(Display Only)</span></label>
+    </div>
+    <input class="dcf-mt-4 dcf-btn dcf-btn-primary submit" type="submit" value="Submit">
 </form>
+<script>
+  var showAllCheckbox = document.getElementById('include-inactive-share-options');
+  if (showAllCheckbox) {
+    showAllCheckbox.addEventListener('change', function() {
+      showShareOptions();
+    });
+  }
+
+  function showShareOptions() {
+    var showAllOptions = document.getElementById('include-inactive-share-options').checked;
+    var shareOptions = document.getElementsByClassName('share_option');
+    var shareOptionsCount = shareOptions.length;
+    for (var i = 0; i < shareOptionsCount; i++) {
+      if (!showAllOptions && shareOptions[i].disabled) {
+        shareOptions[i].style = 'display: none';
+      } else {
+        shareOptions[i].style = 'display: initial';
+      }
+      //Do something
+    }
+  }
+  showShareOptions();
+</script>

--- a/www/templates/default/UNL/VisitorChat/Conversation/Share.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Conversation/Share.tpl.php
@@ -1,3 +1,9 @@
+<div id="shareFormErrorContainer" class="wdn_notice alert" hidden>
+    <div class="message">
+        <h4>Share Error</h4>
+        <p id="shareFormErrorMessage"></p>
+    </div>
+</div>
 <form class="dcf-form" id="shareForm" name="share" action="<?php echo UNL\VisitorChat\Controller::$URLService->generateSiteURL('conversation/' . $context->id . '/share', false, false)?>" method="POST">
     <?php // only one method for here, so use hidden input ?>
     <input type="hidden" name="method" value="invite">
@@ -34,4 +40,19 @@
     }
   }
   showShareOptions();
+
+  var shareForm = document.getElementById('shareForm');
+  shareForm.addEventListener('submit', function(submitEvent) {
+    var shareFormErrorContainer = document.getElementById('shareFormErrorContainer');
+    var shareFormErrorMessage = document.getElementById('shareFormErrorMessage');
+    shareFormErrorContainer.setAttribute('hidden', '');
+    var shareTo = document.getElementById('share_to');
+    if (!shareTo.value || shareTo.value === 'default') {
+      WDN.initializePlugin('notice');
+      submitEvent.preventDefault();
+      shareFormErrorMessage.innerText = 'Please select an operator to share with.';
+      shareFormErrorContainer.removeAttribute('hidden');
+    }
+
+  });
 </script>

--- a/www/templates/default/UNL/VisitorChat/Conversation/ShareList.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Conversation/ShareList.tpl.php
@@ -19,7 +19,7 @@
 
                     //Do not display yourself.
                     if ($account->id == \UNL\VisitorChat\User\Service::getCurrentUser()->id) {
-                        //continue;
+                        continue;
                     }
 
                     $disabled = "disabled='disabled'";

--- a/www/templates/default/UNL/VisitorChat/Conversation/ShareList.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Conversation/ShareList.tpl.php
@@ -1,5 +1,5 @@
-<div id='visitorChat_shareList'>
-    <label for="share_to">Select who you want to share with</label>
+<div class="dcf-form-group">
+    <label for="share_to">Select operator to share with</label>
     <select id='share_to' name='to' data-placeholder='Select a team or group' class='chzn-select dcf-input-select'>
         <option value='default'></option>
         <?php
@@ -9,8 +9,8 @@
                 $disabled = "";
             }
             ?>
-            <optgroup label='<?php echo $site->getTitle();?>' <?php echo $disabled?>>
-                <option value='<?php echo urlencode($site->getURL());?>'>All Operators for <?php echo $site->getTitle();?></option>
+            <optgroup class='share_option' label='<?php echo $site->getTitle();?>' <?php echo $disabled?>>
+                <option class='share_option' value='<?php echo urlencode($site->getURL());?>'>All Operators for <?php echo $site->getTitle();?></option>
                 <?php
                 foreach ($site->getMembers() as $member) {
                     if (!$account = $member->getAccount()) {
@@ -19,7 +19,7 @@
 
                     //Do not display yourself.
                     if ($account->id == \UNL\VisitorChat\User\Service::getCurrentUser()->id) {
-                        continue;
+                        //continue;
                     }
 
                     $disabled = "disabled='disabled'";
@@ -27,7 +27,7 @@
                         $disabled = "";
                     }
 
-                    echo "<option value='" . urlencode($site->getURL()) . "::" . $account->uid . "' " . $disabled . ">" . $account->name . "</option>";
+                    echo "<option class='share_option' value='" . urlencode($site->getURL()) . "::" . $account->uid . "' " . $disabled . ">" . $account->name . "</option>";
                 }
                 ?>
                 </ul>

--- a/www/templates/default/UNL/VisitorChat/Manage/View.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Manage/View.tpl.php
@@ -16,3 +16,13 @@
     </div>
   </div>
 </div>
+<button class="dcf-btn dcf-btn-primary dcf-btn-toggle-modal share-conversation-modal-toggle-btn dcf-invisible" data-toggles-modal="share-conversation-modal" type="button" disabled>Toggle Modal 1</button>
+<div class="dcf-modal" id="share-conversation-modal" hidden>
+    <div class="dcf-modal-wrapper">
+        <div class="dcf-modal-header">
+            <h3>Share This Conversation</h3>
+            <button class="dcf-btn-close-modal">Close</button>
+        </div>
+        <div class="dcf-modal-content" id="share-conversation-modal-content"></div>
+    </div>
+</div>

--- a/www/templates/default/UNL/VisitorChat/Success/View.tpl.php
+++ b/www/templates/default/UNL/VisitorChat/Success/View.tpl.php
@@ -1,6 +1,6 @@
 <?php
 // This plugin is only needed for the demo.
-$page->addScriptDeclartion("WDN.initializePlugin('notice');");
+$page->addScriptDeclaration("WDN.initializePlugin('notice');");
 ?>
 <div class="wdn_notice affirm">
     <div class="close">


### PR DESCRIPTION
Since there's no good way to test (tried chat-test.unl.edu but wasn't opening conversations), I've pointed this branch to production.  This update is pretty much isolated to the share (which didn't appear to post to invite route https://github.com/unl/VisitorChat/blob/develop/www/templates/default/UNL/VisitorChat/Conversation/Share.tpl.php#L2) so should be good. 

So test at https://ucommchat.unl.edu against any site you are an operator on.  I did add both of you to mediahub-test.unl.edu.  FYI.  The chatbot will be active there if no operator is available.

One thing I'm not sure of is the default share option had a value of 'default' and gave a success message when shared to.  I'm not sure it's a real thing so I changed the code to give an error if you try to share to it.  If it's real option, I can remove the error trigger and allow, but then we need to display a label to the user so they no where it goes.
