### PR TITLE
Update HTML Email Template

### DIFF
--- a/www/templates/htmlemail/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
+++ b/www/templates/htmlemail/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
@@ -1,4 +1,44 @@
 <div>
+    <p>
+        <?php
+            // Include assignee info if nu support and assignments are defined
+            if ($context->isNUSupportEmail() && !empty($supportGroupString = trim($context->support_assignments))) {
+
+            // Parse assignments by space allowing for single quote enclosure into array
+            $supportAssignments = str_getcsv($supportGroupString, ' ', "'");
+
+            // Get first assignee as primary
+            echo 'Primary Assignee=' . array_shift($supportAssignments) . "<br />";
+
+            // List any other assignees delimited by commas
+            if (count($supportAssignments)) {
+                echo 'Other Assignees=' . implode(", ", $supportAssignments) . "<br />";
+            }
+            
+            if (!empty(trim($client->email))) {
+                echo 'Email Address=' . trim($client->email) . "<br />";
+            }
+
+            $firstName = 'Website';
+            $lastName = 'User';
+            if (!empty(trim($client->name))) {
+                $nameParts = explode(" ", trim($client->name), 2);
+                if (!empty($nameParts[0])) {
+                $firstName = $nameParts[0];
+                }
+                if (!empty($nameParts[1])) {
+                    $lastName = $nameParts[1];
+                }
+            }
+            echo 'First Name=' . $firstName . "<br />";
+            echo 'Last Name=' . $lastName . "<br />";
+            }
+        ?>
+    </p>
+</div>
+
+
+<div>
     <?php
     $context->messages->rewind();
     $message = $context->messages->current();

--- a/www/templates/textemail/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
+++ b/www/templates/textemail/UNL/VisitorChat/Conversation/FallbackEmail.tpl.php
@@ -4,7 +4,7 @@ $client = $context->conversation->getClient();
 // Include assignee info if nu support and assignments are defined
 if ($context->isNUSupportEmail() && !empty($supportGroupString = trim($context->support_assignments))) {
 
-  // Parse assigments by space allowing for single quote enclosure into array
+  // Parse assignments by space allowing for single quote enclosure into array
   $supportAssignments = str_getcsv($supportGroupString, ' ', "'");
 
   // Get first assignee as primary


### PR DESCRIPTION
HTML Emails were missing key value pairs for basic info. Updated the htmlemail FallbackEmail template so it now matches with the textemail FallbackEmail template

Issue was mentioned in #445 